### PR TITLE
Fix CORS issue in youtube embeds

### DIFF
--- a/templates/finished.html.twig
+++ b/templates/finished.html.twig
@@ -260,7 +260,7 @@
 
   {% apply spaceless %}
     <div class="embed-container" style="margin-top: 20px;">
-      <iframe width="100%" height="600" src="https://www.youtube.com/embed/bwsPWp3aAxo" frameborder="0" allowfullscreen=""></iframe>
+      <iframe width="100%" height="600" src="https://www.youtube.com/embed/bwsPWp3aAxo" frameborder="0" allowfullscreen="" referrerpolicy="strict-origin-when-cross-origin"></iframe>
     </div>
   {% endapply %}
 


### PR DESCRIPTION
Add a missing property to the youtube embed iframe (referrerpolicy="strict-origin-when-cross-origin") This has been preventing the embed playing on site.